### PR TITLE
fixing value type for kalman_noise

### DIFF
--- a/demo_cpm_hand.py
+++ b/demo_cpm_hand.py
@@ -44,7 +44,7 @@ tf.app.flags.DEFINE_integer('cam_num',
 tf.app.flags.DEFINE_bool('KALMAN_ON',
                          default_value=True,
                          docstring='enalbe kalman filter')
-tf.app.flags.DEFINE_integer('kalman_noise',
+tf.app.flags.DEFINE_float('kalman_noise',
                             default_value=3e-2,
                             docstring='Kalman filter noise value')
 tf.app.flags.DEFINE_string('color_channel',


### PR DESCRIPTION
in TF 1.5, the code won't be able to run because the kalman_noise is set to 3e-2 which is a float, but in the flags it's labelled as int, and tensorflow will fail. This PR changes it to it's correct type so it can be run under TF 1.5. 

Other code works fine under TF1.5.